### PR TITLE
distutils.core -> setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 
 """
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name = "youraddon",
     version = "0.0",


### PR DESCRIPTION
entry_points and some other things aren't from distutils. So z3c.dependencychecker gets confused by warnings about the unknown warnings and starts to fail.
